### PR TITLE
[DYOD] Only use valid UCCs in optimization and limit cacheability of plans optimized using UCCs

### DIFF
--- a/src/lib/logical_query_plan/abstract_lqp_node.cpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.cpp
@@ -279,17 +279,18 @@ bool AbstractLQPNode::is_column_nullable(const ColumnID column_id) const {
   return left_input()->is_column_nullable(column_id);
 }
 
-bool AbstractLQPNode::has_matching_ucc(const ExpressionUnorderedSet& expressions) const {
+std::optional<UniqueColumnCombination> AbstractLQPNode::get_matching_ucc(
+    const ExpressionUnorderedSet& expressions) const {
   DebugAssert(!expressions.empty(), "Invalid input. Set of expressions should not be empty.");
   DebugAssert(has_output_expressions(expressions),
               "The given expressions are not a subset of the LQP's output expressions.");
 
   const auto& unique_column_combinations = this->unique_column_combinations();
   if (unique_column_combinations.empty()) {
-    return false;
+    return std::nullopt;
   }
 
-  return contains_matching_unique_column_combination(unique_column_combinations, expressions);
+  return get_matching_unique_column_combination(unique_column_combinations, expressions);
 }
 
 FunctionalDependencies AbstractLQPNode::functional_dependencies() const {

--- a/src/lib/logical_query_plan/abstract_lqp_node.hpp
+++ b/src/lib/logical_query_plan/abstract_lqp_node.hpp
@@ -186,12 +186,12 @@ class AbstractLQPNode : public std::enable_shared_from_this<AbstractLQPNode> {
   virtual UniqueColumnCombinations unique_column_combinations() const = 0;
 
   /**
-   * @return True if there is a unique column combination (UCC) matching the given subset of output expressions (i.e.,
-   *         the rows are guaranteed to be unique). This is preferred over calling
-   *         contains_matching_unique_column_combination(unique_column_combinations(), ...) as it performs additional
+   * @return Finds a unique column combination (UCC) matching the given subset of output expressions (i.e.,
+   *         the rows are guaranteed to be unique), if one exists. This is preferred over calling
+   *         get_matching_unique_column_combination(unique_column_combinations(), ...) as it performs additional
    *         sanity checks.
    */
-  bool has_matching_ucc(const ExpressionUnorderedSet& expressions) const;
+  std::optional<UniqueColumnCombination> get_matching_ucc(const ExpressionUnorderedSet& expressions) const;
 
   /**
    * @return The functional dependencies valid for this node. See functional_dependency.hpp for documentation.

--- a/src/lib/logical_query_plan/aggregate_node.cpp
+++ b/src/lib/logical_query_plan/aggregate_node.cpp
@@ -139,7 +139,7 @@ UniqueColumnCombinations AggregateNode::unique_column_combinations() const {
 
     // Make sure that we do not add an already existing or a superset UCC.
     if (unique_column_combinations.empty() ||
-        !contains_matching_unique_column_combination(unique_column_combinations, group_by_columns)) {
+        !get_matching_unique_column_combination(unique_column_combinations, group_by_columns).has_value()) {
       unique_column_combinations.emplace(group_by_columns);
     }
   }

--- a/src/lib/logical_query_plan/data_dependencies/functional_dependency.hpp
+++ b/src/lib/logical_query_plan/data_dependencies/functional_dependency.hpp
@@ -26,16 +26,25 @@ namespace hyrise {
  *
  * Currently, the determinant expressions are required to be non-nullable to be involved in FDs. Combining null values
  * and FDs is not trivial. For more reference, see https://arxiv.org/abs/1404.4963.
+ *
+ * If the FD may become invalid in the future (because it is not based on a schema constraint, but on the data
+ * incidentally fulfilling the constraint at the moment), the FD is marked as being not permanent.
  */
 struct FunctionalDependency {
   FunctionalDependency(ExpressionUnorderedSet init_determinants, ExpressionUnorderedSet init_dependents);
+  FunctionalDependency(ExpressionUnorderedSet init_determinants, ExpressionUnorderedSet init_dependents,
+                       bool permanent);
 
   bool operator==(const FunctionalDependency& other) const;
   bool operator!=(const FunctionalDependency& other) const;
   size_t hash() const;
 
+  bool is_permanent() const;
+
   ExpressionUnorderedSet determinants;
   ExpressionUnorderedSet dependents;
+
+  bool permanent;
 };
 
 std::ostream& operator<<(std::ostream& stream, const FunctionalDependency& expression);

--- a/src/lib/logical_query_plan/data_dependencies/unique_column_combination.cpp
+++ b/src/lib/logical_query_plan/data_dependencies/unique_column_combination.cpp
@@ -2,9 +2,16 @@
 
 namespace hyrise {
 
-UniqueColumnCombination::UniqueColumnCombination(ExpressionUnorderedSet init_expressions)
-    : expressions(std::move(init_expressions)) {
+UniqueColumnCombination::UniqueColumnCombination(hyrise::ExpressionUnorderedSet init_expressions)
+    : UniqueColumnCombination(std::move(init_expressions), true) {}
+
+UniqueColumnCombination::UniqueColumnCombination(hyrise::ExpressionUnorderedSet init_expressions, bool is_permanent)
+    : expressions(std::move(init_expressions)), permanent(is_permanent) {
   Assert(!expressions.empty(), "UniqueColumnCombination cannot be empty.");
+}
+
+bool UniqueColumnCombination::is_permanent() const {
+  return permanent;
 }
 
 bool UniqueColumnCombination::operator==(const UniqueColumnCombination& rhs) const {

--- a/src/lib/logical_query_plan/data_dependencies/unique_column_combination.hpp
+++ b/src/lib/logical_query_plan/data_dependencies/unique_column_combination.hpp
@@ -12,15 +12,22 @@ namespace hyrise {
  *
  * NOTE: Unique column combinations (UCCs) are only valid for LQP nodes that contain no invalidated rows (i.e., where
  *       there has been a ValidateNode before or where MVCC is disabled).
+ *
+ * If a UCC may become invalid in the future (because it is not based on a schema constraint, but on the data
+ * incidentally being unique at the moment), the UCC is marked as being not permanent.
  */
 struct UniqueColumnCombination final {
   explicit UniqueColumnCombination(ExpressionUnorderedSet init_expressions);
+  explicit UniqueColumnCombination(ExpressionUnorderedSet init_expressions, bool is_permanent);
+
+  bool is_permanent() const;
 
   bool operator==(const UniqueColumnCombination& rhs) const;
   bool operator!=(const UniqueColumnCombination& rhs) const;
   size_t hash() const;
 
   ExpressionUnorderedSet expressions;
+  bool permanent;
 };
 
 std::ostream& operator<<(std::ostream& stream, const UniqueColumnCombination& ucc);

--- a/src/lib/logical_query_plan/join_node.cpp
+++ b/src/lib/logical_query_plan/join_node.cpp
@@ -118,10 +118,12 @@ UniqueColumnCombinations JoinNode::_output_unique_column_combinations(
   // Check uniqueness of join columns.
   const auto left_operand_is_unique =
       !left_unique_column_combinations.empty() &&
-      contains_matching_unique_column_combination(left_unique_column_combinations, {join_predicate->left_operand()});
+      get_matching_unique_column_combination(left_unique_column_combinations, {join_predicate->left_operand()})
+          .has_value();
   const auto right_operand_is_unique =
       !right_unique_column_combinations.empty() &&
-      contains_matching_unique_column_combination(right_unique_column_combinations, {join_predicate->right_operand()});
+      get_matching_unique_column_combination(right_unique_column_combinations, {join_predicate->right_operand()})
+          .has_value();
 
   if (left_operand_is_unique && right_operand_is_unique) {
     // Due to the one-to-one relationship, the UCCs of both sides remain valid.

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -523,7 +523,7 @@ FunctionalDependencies fds_from_unique_column_combinations(const std::shared_ptr
                                return (fd.determinants == determinants) && (fd.dependents == dependents);
                              }) == fds.cend(),
                 "Creating duplicate functional dependencies is unexpected.");
-    fds.emplace(determinants, dependents);
+    fds.emplace(determinants, dependents, ucc.is_permanent());
   }
   return fds;
 }

--- a/src/lib/logical_query_plan/lqp_utils.cpp
+++ b/src/lib/logical_query_plan/lqp_utils.cpp
@@ -462,8 +462,8 @@ template ExpressionUnorderedSet find_column_expressions(const AbstractLQPNode& l
 template ExpressionUnorderedSet find_column_expressions(const AbstractLQPNode& lqp_node,
                                                         const std::vector<ColumnID>& column_ids);
 
-bool contains_matching_unique_column_combination(const UniqueColumnCombinations& unique_column_combinations,
-                                                 const ExpressionUnorderedSet& expressions) {
+std::optional<UniqueColumnCombination> get_matching_unique_column_combination(
+    const UniqueColumnCombinations& unique_column_combinations, const ExpressionUnorderedSet& expressions) {
   DebugAssert(!unique_column_combinations.empty(), "Invalid input: Set of UCCs should not be empty.");
   DebugAssert(!expressions.empty(), "Invalid input: Set of expressions should not be empty.");
 
@@ -473,11 +473,11 @@ bool contains_matching_unique_column_combination(const UniqueColumnCombinations&
         std::all_of(ucc.expressions.cbegin(), ucc.expressions.cend(),
                     [&](const auto& ucc_expression) { return expressions.contains(ucc_expression); })) {
       // Found a matching UCC.
-      return true;
+      return ucc;
     }
   }
   // Did not find a UCC for the given expressions.
-  return false;
+  return std::nullopt;
 }
 
 FunctionalDependencies fds_from_unique_column_combinations(const std::shared_ptr<const AbstractLQPNode>& lqp,

--- a/src/lib/logical_query_plan/lqp_utils.hpp
+++ b/src/lib/logical_query_plan/lqp_utils.hpp
@@ -237,11 +237,11 @@ template <typename ColumnIDs>
 ExpressionUnorderedSet find_column_expressions(const AbstractLQPNode& lqp_node, const ColumnIDs& column_ids);
 
 /**
- * @return True if there is a UCC in the given set of @param unique_column_combinations matching the given set of
- *         expressions. A unique column combination matches if it covers a subset of @param expressions.
+ * @return Returns a UCC in the given set of @param unique_column_combinations matching the given set of
+ *         expressions, if one exists. A unique column combination matches if it covers a subset of @param expressions.
  */
-bool contains_matching_unique_column_combination(const UniqueColumnCombinations& unique_column_combinations,
-                                                 const ExpressionUnorderedSet& expressions);
+std::optional<UniqueColumnCombination> get_matching_unique_column_combination(
+    const UniqueColumnCombinations& unique_column_combinations, const ExpressionUnorderedSet& expressions);
 
 /**
  * @return A set of FDs, derived from the given @param unique_column_combinations and based on the output expressions of

--- a/src/lib/logical_query_plan/mock_node.cpp
+++ b/src/lib/logical_query_plan/mock_node.cpp
@@ -117,7 +117,7 @@ UniqueColumnCombinations MockNode::unique_column_combinations() const {
                 "Unexpected count of column expressions.");
 
     // Create UniqueColumnCombination.
-    unique_column_combinations.emplace(column_expressions);
+    unique_column_combinations.emplace(column_expressions, !table_key_constraint.can_become_invalid());
   }
 
   return unique_column_combinations;

--- a/src/lib/logical_query_plan/stored_table_node.cpp
+++ b/src/lib/logical_query_plan/stored_table_node.cpp
@@ -117,7 +117,7 @@ UniqueColumnCombinations StoredTableNode::unique_column_combinations() const {
                 "Unexpected count of column expressions.");
 
     // Create UniqueColumnCombination
-    unique_column_combinations.emplace(column_expressions);
+    unique_column_combinations.emplace(column_expressions, !table_key_constraint.can_become_invalid());
   }
 
   return unique_column_combinations;

--- a/src/lib/logical_query_plan/stored_table_node.cpp
+++ b/src/lib/logical_query_plan/stored_table_node.cpp
@@ -105,6 +105,12 @@ UniqueColumnCombinations StoredTableNode::unique_column_combinations() const {
       continue;
     }
 
+    // We may only use the key constraints as UCCs for optimization purposes if they are certainly still valid,
+    // otherwise these optimizations could produce invalid query results.
+    if (!table->constraint_guaranteed_to_be_valid(table_key_constraint)) {
+      continue;
+    }
+
     // Search for expressions representing the key constraint's ColumnIDs.
     const auto& column_expressions = find_column_expressions(*this, table_key_constraint.columns());
     DebugAssert(column_expressions.size() == table_key_constraint.columns().size(),

--- a/src/lib/optimizer/optimizer.hpp
+++ b/src/lib/optimizer/optimizer.hpp
@@ -16,6 +16,15 @@ class AbstractRule;
 class AbstractLQPNode;
 
 /**
+ * Holds the result of optimizing an LQP, which consists of the optimized LQP and the information on whether it can be
+ * cached.
+ */
+struct OptimizedLogicalQueryPlan {
+  bool cacheable{true};
+  std::shared_ptr<AbstractLQPNode> logical_query_plan;
+};
+
+/**
  * Applies optimization rules to an LQP.
  * On each invocation of optimize(), these Batches are applied in the same order as they were added
  * to the Optimizer.
@@ -38,7 +47,7 @@ class Optimizer final {
    * Returns optimized version of @param input.
    * @param rule_durations may be set in order to retrieve runtime information for each applied rule.
    */
-  std::shared_ptr<AbstractLQPNode> optimize(
+  OptimizedLogicalQueryPlan optimize(
       std::shared_ptr<AbstractLQPNode> input,
       const std::shared_ptr<std::vector<OptimizerRuleMetrics>>& rule_durations = nullptr) const;
 

--- a/src/lib/optimizer/strategy/abstract_rule.cpp
+++ b/src/lib/optimizer/strategy/abstract_rule.cpp
@@ -9,9 +9,17 @@
 
 namespace hyrise {
 
-void AbstractRule::apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& lqp_root) const {
+IsCacheable operator&(IsCacheable lhs, IsCacheable rhs) {
+  return static_cast<IsCacheable>(static_cast<bool>(lhs) & static_cast<bool>(rhs));
+}
+
+IsCacheable& operator&=(IsCacheable& lhs, const IsCacheable rhs) {
+  return lhs = lhs & rhs;
+}
+
+IsCacheable AbstractRule::apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& lqp_root) const {
   // (1) Optimize root LQP
-  _apply_to_plan_without_subqueries(lqp_root);
+  auto cacheable = _apply_to_plan_without_subqueries(lqp_root);
 
   // (2) Optimize distinct subquery LQPs, one-by-one.
   auto subquery_expressions_by_lqp = collect_lqp_subquery_expressions_by_lqp(lqp_root);
@@ -23,7 +31,7 @@ void AbstractRule::apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& lqp
 
     // (2.1) Optimize subplan
     const auto local_lqp_root = LogicalPlanRootNode::make(lqp);
-    _apply_to_plan_without_subqueries(local_lqp_root);
+    cacheable &= _apply_to_plan_without_subqueries(local_lqp_root);
 
     // (2.2) Assign optimized subplan to all corresponding SubqueryExpressions
     for (const auto& subquery_expression : subquery_expressions) {
@@ -33,6 +41,8 @@ void AbstractRule::apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& lqp
     // (2.3) Untie the root node before it goes out of scope so that the outputs of the LQP remain correct.
     local_lqp_root->set_left_input(nullptr);
   }
+
+  return cacheable;
 }
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/between_composition_rule.cpp
+++ b/src/lib/optimizer/strategy/between_composition_rule.cpp
@@ -54,7 +54,8 @@ std::string BetweenCompositionRule::name() const {
  *   b) The BetweenCompositionRule searches for arbitrary PredicateNodes that are directly linked. Therefore,
  *      predicate chains can start and end in the midst of LQPs.
  */
-void BetweenCompositionRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
+IsCacheable BetweenCompositionRule::_apply_to_plan_without_subqueries(
+    const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   std::unordered_set<std::shared_ptr<AbstractLQPNode>> visited_nodes;
   std::vector<PredicateChain> predicate_chains;
 
@@ -120,6 +121,8 @@ void BetweenCompositionRule::_apply_to_plan_without_subqueries(const std::shared
   for (const auto& predicate_chain : predicate_chains) {
     _substitute_predicates_with_between_expressions(predicate_chain);
   }
+
+  return IsCacheable::Yes;
 }
 
 /**

--- a/src/lib/optimizer/strategy/between_composition_rule.hpp
+++ b/src/lib/optimizer/strategy/between_composition_rule.hpp
@@ -30,7 +30,7 @@ class BetweenCompositionRule : public AbstractRule {
   std::string name() const override;
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 
  private:
   using PredicateChain = std::vector<std::shared_ptr<PredicateNode>>;

--- a/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/chunk_pruning_rule.cpp
@@ -135,7 +135,8 @@ std::string ChunkPruningRule::name() const {
   return name;
 }
 
-void ChunkPruningRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
+IsCacheable ChunkPruningRule::_apply_to_plan_without_subqueries(
+    const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   auto predicate_pruning_chains_by_stored_table_node =
       std::unordered_map<std::shared_ptr<StoredTableNode>, std::vector<PredicatePruningChain>>{};
 
@@ -173,6 +174,8 @@ void ChunkPruningRule::_apply_to_plan_without_subqueries(const std::shared_ptr<A
     // Wanted side effect of using sets: pruned_chunk_ids vector is already sorted.
     stored_table_node->set_pruned_chunk_ids(std::vector<ChunkID>(pruned_chunk_ids.begin(), pruned_chunk_ids.end()));
   }
+
+  return IsCacheable::Yes;
 }
 
 /**

--- a/src/lib/optimizer/strategy/chunk_pruning_rule.hpp
+++ b/src/lib/optimizer/strategy/chunk_pruning_rule.hpp
@@ -27,7 +27,7 @@ class ChunkPruningRule : public AbstractRule {
   std::string name() const override;
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 
   static std::vector<PredicatePruningChain> _find_predicate_pruning_chains_by_stored_table_node(
       const std::shared_ptr<StoredTableNode>& stored_table_node);

--- a/src/lib/optimizer/strategy/column_pruning_rule.cpp
+++ b/src/lib/optimizer/strategy/column_pruning_rule.cpp
@@ -322,7 +322,8 @@ std::string ColumnPruningRule::name() const {
   return name;
 }
 
-void ColumnPruningRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
+IsCacheable ColumnPruningRule::_apply_to_plan_without_subqueries(
+    const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   // For each node, required_expressions_by_node will hold the expressions either needed by this node or by one of its
   // successors (i.e., nodes to which this node is an input). After collecting this information, we walk through all
   // identified nodes and perform the pruning.
@@ -386,6 +387,8 @@ void ColumnPruningRule::_apply_to_plan_without_subqueries(const std::shared_ptr<
         break;  // Node cannot be pruned
     }
   }
+
+  return IsCacheable::Yes;
 }
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/column_pruning_rule.hpp
+++ b/src/lib/optimizer/strategy/column_pruning_rule.hpp
@@ -21,7 +21,7 @@ class ColumnPruningRule : public AbstractRule {
   std::string name() const override;
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/dependent_group_by_reduction_rule.cpp
+++ b/src/lib/optimizer/strategy/dependent_group_by_reduction_rule.cpp
@@ -72,8 +72,10 @@ std::string DependentGroupByReductionRule::name() const {
   return name;
 }
 
-void DependentGroupByReductionRule::_apply_to_plan_without_subqueries(
+IsCacheable DependentGroupByReductionRule::_apply_to_plan_without_subqueries(
     const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
+  auto rule_was_applied_using_non_permanent_ucc = false;
+
   visit_lqp(lqp_root, [&](const auto& node) {
     if (node->type != LQPNodeType::Aggregate) {
       return LQPVisitation::VisitInputs;
@@ -187,6 +189,8 @@ void DependentGroupByReductionRule::_apply_to_plan_without_subqueries(
 
     return LQPVisitation::VisitInputs;
   });
+
+  return rule_was_applied_using_non_permanent_ucc ? IsCacheable::No : IsCacheable::Yes;
 }
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/dependent_group_by_reduction_rule.hpp
+++ b/src/lib/optimizer/strategy/dependent_group_by_reduction_rule.hpp
@@ -41,7 +41,7 @@ class DependentGroupByReductionRule : public AbstractRule {
   std::string name() const override;
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/expression_reduction_rule.cpp
+++ b/src/lib/optimizer/strategy/expression_reduction_rule.cpp
@@ -23,7 +23,7 @@ std::string ExpressionReductionRule::name() const {
   return name;
 }
 
-void ExpressionReductionRule::_apply_to_plan_without_subqueries(
+IsCacheable ExpressionReductionRule::_apply_to_plan_without_subqueries(
     const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   Assert(lqp_root->type == LQPNodeType::Root, "ExpressionReductionRule needs root to hold onto");
 
@@ -50,6 +50,8 @@ void ExpressionReductionRule::_apply_to_plan_without_subqueries(
 
     return LQPVisitation::VisitInputs;
   });
+
+  return IsCacheable::Yes;
 }
 
 const std::shared_ptr<AbstractExpression>& ExpressionReductionRule::reduce_distributivity(

--- a/src/lib/optimizer/strategy/expression_reduction_rule.hpp
+++ b/src/lib/optimizer/strategy/expression_reduction_rule.hpp
@@ -62,7 +62,7 @@ class ExpressionReductionRule : public AbstractRule {
                                          const std::shared_ptr<AbstractLQPNode>& root_node);
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/in_expression_rewrite_rule.cpp
+++ b/src/lib/optimizer/strategy/in_expression_rewrite_rule.cpp
@@ -114,11 +114,11 @@ std::shared_ptr<AbstractCardinalityEstimator> InExpressionRewriteRule::_cardinal
   return _cardinality_estimator_internal;
 }
 
-void InExpressionRewriteRule::_apply_to_plan_without_subqueries(
+IsCacheable InExpressionRewriteRule::_apply_to_plan_without_subqueries(
     const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   if (strategy == Strategy::ExpressionEvaluator) {
     // This is the default anyway, i.e., what the SQLTranslator gave us
-    return;
+    return IsCacheable::Yes;
   }
 
   visit_lqp(lqp_root, [&](const auto& sub_node) {
@@ -190,6 +190,8 @@ void InExpressionRewriteRule::_apply_to_plan_without_subqueries(
 
     return LQPVisitation::VisitInputs;
   });
+
+  return IsCacheable::Yes;
 }
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/in_expression_rewrite_rule.hpp
+++ b/src/lib/optimizer/strategy/in_expression_rewrite_rule.hpp
@@ -39,7 +39,7 @@ class InExpressionRewriteRule : public AbstractRule {
   Strategy strategy{Strategy::Auto};
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 
   std::shared_ptr<AbstractCardinalityEstimator> _cardinality_estimator() const;
 

--- a/src/lib/optimizer/strategy/index_scan_rule.cpp
+++ b/src/lib/optimizer/strategy/index_scan_rule.cpp
@@ -34,7 +34,7 @@ std::string IndexScanRule::name() const {
   return name;
 }
 
-void IndexScanRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
+IsCacheable IndexScanRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   DebugAssert(cost_estimator, "IndexScanRule requires cost estimator to be set");
   Assert(lqp_root->type == LQPNodeType::Root, "ExpressionReductionRule needs root to hold onto");
 
@@ -57,6 +57,8 @@ void IndexScanRule::_apply_to_plan_without_subqueries(const std::shared_ptr<Abst
 
     return LQPVisitation::VisitInputs;
   });
+
+  return IsCacheable::Yes;
 }
 
 bool IndexScanRule::_is_index_scan_applicable(const ChunkIndexStatistics& index_statistics,

--- a/src/lib/optimizer/strategy/index_scan_rule.hpp
+++ b/src/lib/optimizer/strategy/index_scan_rule.hpp
@@ -30,7 +30,7 @@ class IndexScanRule : public AbstractRule {
   std::string name() const override;
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
   bool _is_index_scan_applicable(const ChunkIndexStatistics& index_statistics,
                                  const std::shared_ptr<PredicateNode>& predicate_node) const;
   static bool _is_single_segment_index(const ChunkIndexStatistics& index_statistics);

--- a/src/lib/optimizer/strategy/join_ordering_rule.cpp
+++ b/src/lib/optimizer/strategy/join_ordering_rule.cpp
@@ -18,7 +18,8 @@ std::string JoinOrderingRule::name() const {
   return name;
 }
 
-void JoinOrderingRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
+IsCacheable JoinOrderingRule::_apply_to_plan_without_subqueries(
+    const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   DebugAssert(cost_estimator, "JoinOrderingRule requires cost estimator to be set");
 
   /**
@@ -38,6 +39,8 @@ void JoinOrderingRule::_apply_to_plan_without_subqueries(const std::shared_ptr<A
   }
 
   lqp_root->set_left_input(result_lqp);
+
+  return IsCacheable::Yes;
 }
 
 std::shared_ptr<AbstractLQPNode> JoinOrderingRule::_perform_join_ordering_recursively(

--- a/src/lib/optimizer/strategy/join_ordering_rule.hpp
+++ b/src/lib/optimizer/strategy/join_ordering_rule.hpp
@@ -17,7 +17,7 @@ class JoinOrderingRule : public AbstractRule {
   std::string name() const override;
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 
  private:
   std::shared_ptr<AbstractLQPNode> _perform_join_ordering_recursively(

--- a/src/lib/optimizer/strategy/join_predicate_ordering_rule.cpp
+++ b/src/lib/optimizer/strategy/join_predicate_ordering_rule.cpp
@@ -16,7 +16,7 @@ std::string JoinPredicateOrderingRule::name() const {
   return name;
 }
 
-void JoinPredicateOrderingRule::_apply_to_plan_without_subqueries(
+IsCacheable JoinPredicateOrderingRule::_apply_to_plan_without_subqueries(
     const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   visit_lqp(lqp_root, [&](const auto& node) {
     // Check if this is a multi predicate join.
@@ -67,6 +67,8 @@ void JoinPredicateOrderingRule::_apply_to_plan_without_subqueries(
 
     return LQPVisitation::VisitInputs;
   });
+
+  return IsCacheable::Yes;
 }
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/join_predicate_ordering_rule.hpp
+++ b/src/lib/optimizer/strategy/join_predicate_ordering_rule.hpp
@@ -24,7 +24,7 @@ class JoinPredicateOrderingRule : public AbstractRule {
   std::string name() const override;
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/join_to_predicate_rewrite_rule.cpp
+++ b/src/lib/optimizer/strategy/join_to_predicate_rewrite_rule.cpp
@@ -51,7 +51,7 @@ void gather_rewrite_info(
          "Neither column of the join predicate could be evaluated on the removable input.");
 
   // Check for uniqueness.
-  if (!removable_subtree->has_matching_ucc({exchangeable_column_expression})) {
+  if (!removable_subtree->get_matching_ucc({exchangeable_column_expression}).has_value()) {
     return;
   }
 
@@ -59,54 +59,60 @@ void gather_rewrite_info(
   // predicate that filters on a UCC, a maximum of one tuple remains in the result relation. Since at this point, we al-
   // ready know the candidate join is basically a semi join, we can further transform the join to a single predicate
   // node filtering the join column for the value of the remaining tuple's join attribute.
-  visit_lqp(removable_subtree, [&removable_subtree, &rewrite_predicate](auto& current_node) {
-    if (current_node->type == LQPNodeType::Union) {
-      return LQPVisitation::DoNotVisitInputs;
-    }
-    if (current_node->type != LQPNodeType::Predicate) {
-      return LQPVisitation::VisitInputs;
-    }
+  visit_lqp(
+      removable_subtree, [&removable_subtree, &rewrite_predicate, &non_permanent_ucc_was_used](auto& current_node) {
+        if (current_node->type == LQPNodeType::Union) {
+          return LQPVisitation::DoNotVisitInputs;
+        }
+        if (current_node->type != LQPNodeType::Predicate) {
+          return LQPVisitation::VisitInputs;
+        }
 
-    // We need to get a predicate node with a BinaryPredicateExpression.
-    const auto candidate = std::static_pointer_cast<PredicateNode>(current_node);
-    const auto candidate_expression = std::dynamic_pointer_cast<BinaryPredicateExpression>(candidate->predicate());
-    if (!candidate_expression) {
-      return LQPVisitation::VisitInputs;
-    }
+        // We need to get a predicate node with a BinaryPredicateExpression.
+        const auto candidate = std::static_pointer_cast<PredicateNode>(current_node);
+        const auto candidate_expression = std::dynamic_pointer_cast<BinaryPredicateExpression>(candidate->predicate());
+        if (!candidate_expression) {
+          return LQPVisitation::VisitInputs;
+        }
 
-    // Only predicates in the form `column = value` are useful to our optimization. These conditions have the potential
-    // (given filtered column is a UCC) to emit at most one result tuple.
-    if (candidate_expression->predicate_condition != PredicateCondition::Equals)
-      return LQPVisitation::VisitInputs;
+        // Only predicates in the form `column = value` are useful to our optimization. These conditions have the
+        // potential (given filtered column is a UCC) to emit at most one result tuple.
+        if (candidate_expression->predicate_condition != PredicateCondition::Equals) {
+          return LQPVisitation::VisitInputs;
+        }
 
-    auto candidate_column_expression = std::shared_ptr<AbstractExpression>{};
-    auto candidate_value_expression = std::shared_ptr<AbstractExpression>{};
+        auto candidate_column_expression = std::shared_ptr<AbstractExpression>{};
+        auto candidate_value_expression = std::shared_ptr<AbstractExpression>{};
 
-    for (const auto& predicate_operand : candidate_expression->arguments) {
-      if (predicate_operand->type == ExpressionType::LQPColumn) {
-        candidate_column_expression = predicate_operand;
-      } else if (predicate_operand->type == ExpressionType::Value) {
-        candidate_value_expression = predicate_operand;
-      }
-    }
+        for (const auto& predicate_operand : candidate_expression->arguments) {
+          if (predicate_operand->type == ExpressionType::LQPColumn) {
+            candidate_column_expression = predicate_operand;
+          } else if (predicate_operand->type == ExpressionType::Value) {
+            candidate_value_expression = predicate_operand;
+          }
+        }
 
-    // There should not be a case where we run into no column, but there may be a case where we have no value but
-    // compare columns.
-    if (!candidate_value_expression || !candidate_column_expression) {
-      return LQPVisitation::VisitInputs;
-    }
+        // There should not be a case where we run into no column, but there may be a case where we have no value but
+        // compare columns.
+        if (!candidate_value_expression || !candidate_column_expression) {
+          return LQPVisitation::VisitInputs;
+        }
 
-    // Check whether the referenced column is available for the subtree root node and unique. Checking whether the
-    // column is unique on the current node is not sufficient. There could be unions or joins in between the subtree
-    // root and the current node, invalidating the unique column combination.
-    if (!expression_evaluable_on_lqp(candidate_column_expression, *removable_subtree) ||
-        !removable_subtree->has_matching_ucc({candidate_column_expression})) {
-      return LQPVisitation::VisitInputs;
-    }
+        // Check whether the referenced column is available for the subtree root node and unique. Checking whether the
+        // column is unique on the current node is not sufficient. There could be unions or joins in between the subtree
+        // root and the current node, invalidating the unique column combination.
+        if (!expression_evaluable_on_lqp(candidate_column_expression, *removable_subtree)) {
+          return LQPVisitation::VisitInputs;
+        }
+        auto matching_ucc = removable_subtree->get_matching_ucc({candidate_column_expression});
+        if (!matching_ucc.has_value()) {
+          return LQPVisitation::VisitInputs;
+        }
 
-    rewrite_predicate = candidate;
-    return LQPVisitation::DoNotVisitInputs;
-  });
+        rewrite_predicate = candidate;
+        non_permanent_ucc_was_used |= !matching_ucc->is_permanent();
+        return LQPVisitation::DoNotVisitInputs;
+      });
 
   if (rewrite_predicate) {
     rewritables.emplace_back(join_node, *prunable_side, rewrite_predicate);

--- a/src/lib/optimizer/strategy/join_to_predicate_rewrite_rule.hpp
+++ b/src/lib/optimizer/strategy/join_to_predicate_rewrite_rule.hpp
@@ -22,7 +22,7 @@ class JoinToPredicateRewriteRule : public AbstractRule {
   std::string name() const override;
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/join_to_semi_join_rule.cpp
+++ b/src/lib/optimizer/strategy/join_to_semi_join_rule.cpp
@@ -16,7 +16,9 @@ std::string JoinToSemiJoinRule::name() const {
   return name;
 }
 
-void JoinToSemiJoinRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
+IsCacheable JoinToSemiJoinRule::_apply_to_plan_without_subqueries(
+    const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
+  auto rule_was_applied_using_non_permanent_ucc = false;
   visit_lqp(lqp_root, [&](const auto& node) {
     // Sometimes, joins are not actually used to combine tables but only to check the existence of a tuple in a second
     // table. Example: SELECT c_name FROM customer, nation WHERE c_nationkey = n_nationkey AND n_name = 'GERMANY'
@@ -86,6 +88,8 @@ void JoinToSemiJoinRule::_apply_to_plan_without_subqueries(const std::shared_ptr
 
     return LQPVisitation::VisitInputs;
   });
+
+  return rule_was_applied_using_non_permanent_ucc ? IsCacheable::No : IsCacheable::Yes;
 }
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/join_to_semi_join_rule.hpp
+++ b/src/lib/optimizer/strategy/join_to_semi_join_rule.hpp
@@ -19,7 +19,7 @@ class JoinToSemiJoinRule : public AbstractRule {
   std::string name() const override;
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/null_scan_removal_rule.cpp
+++ b/src/lib/optimizer/strategy/null_scan_removal_rule.cpp
@@ -27,7 +27,7 @@ std::string NullScanRemovalRule::name() const {
   return name;
 }
 
-void NullScanRemovalRule::apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& root) const {
+IsCacheable NullScanRemovalRule::apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& root) const {
   Assert(root->type == LQPNodeType::Root, "NullScanRemovalRule needs root to hold onto");
 
   std::vector<std::shared_ptr<AbstractLQPNode>> nodes_to_remove;
@@ -86,6 +86,8 @@ void NullScanRemovalRule::apply_to_plan(const std::shared_ptr<LogicalPlanRootNod
   visit_lqp(root, visitor);
 
   _remove_nodes(nodes_to_remove);
+
+  return IsCacheable::Yes;
 }
 
 void NullScanRemovalRule::_remove_nodes(const std::vector<std::shared_ptr<AbstractLQPNode>>& nodes) {
@@ -94,7 +96,7 @@ void NullScanRemovalRule::_remove_nodes(const std::vector<std::shared_ptr<Abstra
   }
 }
 
-void NullScanRemovalRule::_apply_to_plan_without_subqueries(
+IsCacheable NullScanRemovalRule::_apply_to_plan_without_subqueries(
     const std::shared_ptr<AbstractLQPNode>& /*lqp_root*/) const {
   Fail("Did not expect this function to be called.");
 }

--- a/src/lib/optimizer/strategy/null_scan_removal_rule.hpp
+++ b/src/lib/optimizer/strategy/null_scan_removal_rule.hpp
@@ -15,14 +15,14 @@ class PredicateNode;
 // It does not yet deal with IsNotNull predicates or cases where Is(Not)Null is nested within another expression.
 class NullScanRemovalRule : public AbstractRule {
  public:
-  void apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& root) const override;
+  IsCacheable apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& root) const override;
   std::string name() const override;
 
  private:
   static void _remove_nodes(const std::vector<std::shared_ptr<AbstractLQPNode>>& nodes);
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& /*lqp_root*/) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& /*lqp_root*/) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/predicate_merge_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_merge_rule.cpp
@@ -38,7 +38,8 @@ std::string PredicateMergeRule::name() const {
  * that are inputs to a merged subplan but do not necessarily belong to that subplan. When it becomes necessary, this
  * rule might be adapted to make more sophisticated decisions on which predicates to include.
  */
-void PredicateMergeRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
+IsCacheable PredicateMergeRule::_apply_to_plan_without_subqueries(
+    const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   Assert(lqp_root->type == LQPNodeType::Root, "PredicateMergeRule needs root to hold onto");
 
   // (Potentially mergeable) subplans are identified by their topmost UnionNode. node_to_topmost holds a mapping from
@@ -109,6 +110,8 @@ void PredicateMergeRule::_apply_to_plan_without_subqueries(const std::shared_ptr
       }
     }
   }
+
+  return IsCacheable::Yes;
 }
 
 /**

--- a/src/lib/optimizer/strategy/predicate_merge_rule.hpp
+++ b/src/lib/optimizer/strategy/predicate_merge_rule.hpp
@@ -25,7 +25,7 @@ class PredicateMergeRule : public AbstractRule {
   size_t minimum_union_count{4};
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 
  private:
   void _merge_disjunction(const std::shared_ptr<UnionNode>& union_node) const;

--- a/src/lib/optimizer/strategy/predicate_placement_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.cpp
@@ -23,7 +23,8 @@ std::string PredicatePlacementRule::name() const {
   return name;
 }
 
-void PredicatePlacementRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
+IsCacheable PredicatePlacementRule::_apply_to_plan_without_subqueries(
+    const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   // The traversal functions require the existence of a root of the LQP, so make sure we have that
   const auto root_node = lqp_root->type == LQPNodeType::Root ? lqp_root : LogicalPlanRootNode::make(lqp_root);
 
@@ -34,6 +35,8 @@ void PredicatePlacementRule::_apply_to_plan_without_subqueries(const std::shared
   _push_down_traversal(root_node, LQPInputSide::Left, push_down_nodes, *estimator);
 
   _pull_up_traversal(root_node, LQPInputSide::Left);
+
+  return IsCacheable::Yes;
 }
 
 void PredicatePlacementRule::_push_down_traversal(const std::shared_ptr<AbstractLQPNode>& current_node,

--- a/src/lib/optimizer/strategy/predicate_placement_rule.hpp
+++ b/src/lib/optimizer/strategy/predicate_placement_rule.hpp
@@ -23,7 +23,7 @@ class PredicatePlacementRule : public AbstractRule {
   std::string name() const override;
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 
  private:
   // Traverse the LQP and perform push downs of predicates.

--- a/src/lib/optimizer/strategy/predicate_reordering_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_reordering_rule.cpp
@@ -52,7 +52,7 @@ std::string PredicateReorderingRule::name() const {
   return name;
 }
 
-void PredicateReorderingRule::_apply_to_plan_without_subqueries(
+IsCacheable PredicateReorderingRule::_apply_to_plan_without_subqueries(
     const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   DebugAssert(cost_estimator, "PredicateReorderingRule requires cost estimator to be set");
   Assert(lqp_root->type == LQPNodeType::Root, "PredicateReorderingRule needs root to hold onto");
@@ -89,6 +89,8 @@ void PredicateReorderingRule::_apply_to_plan_without_subqueries(
 
     return LQPVisitation::VisitInputs;
   });
+
+  return IsCacheable::Yes;
 }
 
 void PredicateReorderingRule::_reorder_predicates(

--- a/src/lib/optimizer/strategy/predicate_reordering_rule.hpp
+++ b/src/lib/optimizer/strategy/predicate_reordering_rule.hpp
@@ -28,7 +28,7 @@ class PredicateReorderingRule : public AbstractRule {
   std::string name() const override;
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 
  private:
   void _reorder_predicates(const std::vector<std::shared_ptr<AbstractLQPNode>>& predicates) const;

--- a/src/lib/optimizer/strategy/predicate_split_up_rule.cpp
+++ b/src/lib/optimizer/strategy/predicate_split_up_rule.cpp
@@ -80,7 +80,8 @@ std::string PredicateSplitUpRule::name() const {
   return name;
 }
 
-void PredicateSplitUpRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
+IsCacheable PredicateSplitUpRule::_apply_to_plan_without_subqueries(
+    const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   Assert(lqp_root->type == LQPNodeType::Root, "PredicateSplitUpRule needs root to hold onto");
 
   auto predicate_nodes = std::vector<std::shared_ptr<PredicateNode>>{};
@@ -98,6 +99,8 @@ void PredicateSplitUpRule::_apply_to_plan_without_subqueries(const std::shared_p
       _split_disjunction(predicate_node);
     }
   }
+
+  return IsCacheable::Yes;
 }
 
 /**

--- a/src/lib/optimizer/strategy/predicate_split_up_rule.hpp
+++ b/src/lib/optimizer/strategy/predicate_split_up_rule.hpp
@@ -30,7 +30,7 @@ class PredicateSplitUpRule : public AbstractRule {
   std::string name() const override;
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 
  private:
   void _split_conjunction(const std::shared_ptr<PredicateNode>& predicate_node) const;

--- a/src/lib/optimizer/strategy/semi_join_reduction_rule.cpp
+++ b/src/lib/optimizer/strategy/semi_join_reduction_rule.cpp
@@ -14,7 +14,8 @@ std::string SemiJoinReductionRule::name() const {
   return name;
 }
 
-void SemiJoinReductionRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
+IsCacheable SemiJoinReductionRule::_apply_to_plan_without_subqueries(
+    const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   Assert(lqp_root->type == LQPNodeType::Root, "Rule needs root to hold onto");
 
   // Adding semi joins inside visit_lqp might lead to endless recursions. Thus, we use visit_lqp to identify the
@@ -157,5 +158,7 @@ void SemiJoinReductionRule::_apply_to_plan_without_subqueries(const std::shared_
   for (const auto& [join_node, side_of_join, semi_join_reduction_node] : semi_join_reductions) {
     lqp_insert_node(join_node, side_of_join, semi_join_reduction_node, AllowRightInput::Yes);
   }
+
+  return IsCacheable::Yes;
 }
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/semi_join_reduction_rule.hpp
+++ b/src/lib/optimizer/strategy/semi_join_reduction_rule.hpp
@@ -52,7 +52,7 @@ class SemiJoinReductionRule : public AbstractRule {
   constexpr static auto MINIMUM_SELECTIVITY = .25;
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/stored_table_column_alignment_rule.cpp
+++ b/src/lib/optimizer/strategy/stored_table_column_alignment_rule.cpp
@@ -103,7 +103,7 @@ std::string StoredTableColumnAlignmentRule::name() const {
  * The default implementation of this function optimizes a given LQP and all of its subquery LQPs individually.
  * However, as we do not want to align StoredTableNodes per plan but across all plans, we override it accordingly.
  */
-void StoredTableColumnAlignmentRule::apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& root_node) const {
+IsCacheable StoredTableColumnAlignmentRule::apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& root_node) const {
   // (1) Collect all plans
   auto lqps = std::vector<std::shared_ptr<AbstractLQPNode>>();
   lqps.emplace_back(std::static_pointer_cast<AbstractLQPNode>(root_node));
@@ -117,9 +117,11 @@ void StoredTableColumnAlignmentRule::apply_to_plan(const std::shared_ptr<Logical
 
   // (3) Align grouped StoredTableNodes
   align_pruned_column_ids(grouped_stored_table_nodes);
+
+  return IsCacheable::Yes;
 }
 
-void StoredTableColumnAlignmentRule::_apply_to_plan_without_subqueries(
+IsCacheable StoredTableColumnAlignmentRule::_apply_to_plan_without_subqueries(
     const std::shared_ptr<AbstractLQPNode>& /*lqp_root*/) const {
   Fail("Did not expect this function to be called.");
 }

--- a/src/lib/optimizer/strategy/stored_table_column_alignment_rule.hpp
+++ b/src/lib/optimizer/strategy/stored_table_column_alignment_rule.hpp
@@ -62,11 +62,11 @@ namespace hyrise {
 
 class StoredTableColumnAlignmentRule : public AbstractRule {
  public:
-  void apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& root_node) const override;
+  IsCacheable apply_to_plan(const std::shared_ptr<LogicalPlanRootNode>& root_node) const override;
   std::string name() const override;
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& /*lqp_root*/) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& /*lqp_root*/) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/subquery_to_join_rule.cpp
+++ b/src/lib/optimizer/strategy/subquery_to_join_rule.cpp
@@ -543,7 +543,8 @@ SubqueryToJoinRule::PredicatePullUpResult SubqueryToJoinRule::pull_up_correlated
   return pull_up_correlated_predicates_recursive(node, parameter_mapping, result_cache, false).first;
 }
 
-void SubqueryToJoinRule::_apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
+IsCacheable SubqueryToJoinRule::_apply_to_plan_without_subqueries(
+    const std::shared_ptr<AbstractLQPNode>& lqp_root) const {
   // While visiting the LQP, PredicateNodes might become replaced with JoinNodes. Instead of using recursion, we use
   // a node queue to schedule visitation of replaced/newly-inserted nodes.
   std::unordered_set<std::shared_ptr<AbstractLQPNode>> visited_nodes;
@@ -661,6 +662,8 @@ void SubqueryToJoinRule::_apply_to_plan_without_subqueries(const std::shared_ptr
       return LQPVisitation::DoNotVisitInputs;
     });
   }
+
+  return IsCacheable::Yes;
 }
 
 }  // namespace hyrise

--- a/src/lib/optimizer/strategy/subquery_to_join_rule.hpp
+++ b/src/lib/optimizer/strategy/subquery_to_join_rule.hpp
@@ -127,7 +127,7 @@ class SubqueryToJoinRule : public AbstractRule {
       const std::map<ParameterID, std::shared_ptr<AbstractExpression>>& parameter_mapping);
 
  protected:
-  void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
+  IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override;
 };
 
 }  // namespace hyrise

--- a/src/lib/server/query_handler.cpp
+++ b/src/lib/server/query_handler.cpp
@@ -90,7 +90,7 @@ std::shared_ptr<AbstractOperator> QueryHandler::bind_prepared_plan(const Prepare
 
   auto lqp = prepared_plan->instantiate(parameter_expressions);
   const auto optimizer = Optimizer::create_default_optimizer();
-  lqp = optimizer->optimize(std::move(lqp));
+  lqp = optimizer->optimize(std::move(lqp)).logical_query_plan;
 
   auto pqp = LQPTranslator{}.translate_node(lqp);
 

--- a/src/lib/sql/sql_pipeline.cpp
+++ b/src/lib/sql/sql_pipeline.cpp
@@ -171,7 +171,7 @@ const std::vector<std::shared_ptr<AbstractLQPNode>>& SQLPipeline::get_optimized_
 
   _optimized_logical_plans.reserve(statement_count());
   for (auto& pipeline_statement : _sql_pipeline_statements) {
-    _optimized_logical_plans.emplace_back(pipeline_statement->get_optimized_logical_plan());
+    _optimized_logical_plans.emplace_back(pipeline_statement->get_optimized_logical_plan().logical_query_plan);
   }
 
   return _optimized_logical_plans;

--- a/src/lib/sql/sql_pipeline_statement.cpp
+++ b/src/lib/sql/sql_pipeline_statement.cpp
@@ -2,17 +2,12 @@
 
 #include <fstream>
 #include <iomanip>
-#include <memory>
 #include <utility>
-
-#include <boost/algorithm/string.hpp>
 
 #include "SQLParser.h"
 #include "create_sql_parser_error_message.hpp"
-#include "expression/value_expression.hpp"
 #include "hyrise.hpp"
 #include "logical_query_plan/lqp_utils.hpp"
-#include "operators/export.hpp"
 #include "operators/import.hpp"
 #include "operators/maintenance/create_prepared_plan.hpp"
 #include "operators/maintenance/create_table.hpp"
@@ -21,7 +16,6 @@
 #include "operators/maintenance/drop_view.hpp"
 #include "optimizer/optimizer.hpp"
 #include "scheduler/job_task.hpp"
-#include "sql/sql_pipeline_builder.hpp"
 #include "sql/sql_plan_cache.hpp"
 #include "sql/sql_translator.hpp"
 #include "utils/assert.hpp"
@@ -109,8 +103,8 @@ const SQLTranslationInfo& SQLPipelineStatement::get_sql_translation_info() {
   return _translation_info;
 }
 
-const std::shared_ptr<AbstractLQPNode>& SQLPipelineStatement::get_optimized_logical_plan() {
-  if (_optimized_logical_plan) {
+OptimizedLogicalQueryPlan SQLPipelineStatement::get_optimized_logical_plan() {
+  if (_optimized_logical_plan.logical_query_plan) {
     return _optimized_logical_plan;
   }
 
@@ -123,7 +117,7 @@ const std::shared_ptr<AbstractLQPNode>& SQLPipelineStatement::get_optimized_logi
       if (lqp_is_validated(plan) == (_use_mvcc == UseMvcc::Yes)) {
         // Copy the LQP for reuse as the LQPTranslator might modify mutable fields (e.g., cached output_expressions)
         // and concurrent translations might conflict.
-        _optimized_logical_plan = plan->deep_copy();
+        _optimized_logical_plan = {true, plan->deep_copy()};
         return _optimized_logical_plan;
       }
     }
@@ -147,8 +141,8 @@ const std::shared_ptr<AbstractLQPNode>& SQLPipelineStatement::get_optimized_logi
   _metrics->optimizer_rule_durations = *optimizer_rule_durations;
 
   // Cache newly created plan for the according sql statement
-  if (lqp_cache && _translation_info.cacheable) {
-    lqp_cache->set(_sql_string, _optimized_logical_plan);
+  if (lqp_cache && _translation_info.cacheable && _optimized_logical_plan.cacheable) {
+    lqp_cache->set(_sql_string, _optimized_logical_plan.logical_query_plan);
   }
 
   return _optimized_logical_plan;
@@ -182,10 +176,12 @@ const std::shared_ptr<AbstractOperator>& SQLPipelineStatement::get_physical_plan
     }
   }
 
+  bool pqp_cacheable = true;
   if (!_physical_plan) {
     // "Normal" path in which the query plan is created instead of begin retrieved from cache
-    const auto& lqp = get_optimized_logical_plan();
-
+    const auto& optimization_result = get_optimized_logical_plan();
+    pqp_cacheable = optimization_result.cacheable;
+    const auto& lqp = optimization_result.logical_query_plan;
     // Reset time to exclude previous pipeline steps
     started = std::chrono::steady_clock::now();
     _physical_plan = LQPTranslator{}.translate_node(lqp);
@@ -198,7 +194,7 @@ const std::shared_ptr<AbstractOperator>& SQLPipelineStatement::get_physical_plan
   }
 
   // Cache newly created plan for the according sql statement (only if not already cached)
-  if (pqp_cache && !_metrics->query_plan_cache_hit && _translation_info.cacheable) {
+  if (pqp_cache && !_metrics->query_plan_cache_hit && _translation_info.cacheable && pqp_cacheable) {
     pqp_cache->set(_sql_string, _physical_plan);
   }
 

--- a/src/lib/sql/sql_pipeline_statement.hpp
+++ b/src/lib/sql/sql_pipeline_statement.hpp
@@ -75,7 +75,7 @@ class SQLPipelineStatement : public Noncopyable {
   const SQLTranslationInfo& get_sql_translation_info();
 
   // Returns the optimized LQP for this statement.
-  const std::shared_ptr<AbstractLQPNode>& get_optimized_logical_plan();
+  OptimizedLogicalQueryPlan get_optimized_logical_plan();
 
   // Returns the PQP for this statement.
   // The physical plan is either retrieved from the SQLPhysicalPlanCache or, if unavailable, translated from the
@@ -122,7 +122,7 @@ class SQLPipelineStatement : public Noncopyable {
   // Execution results
   std::shared_ptr<hsql::SQLParserResult> _parsed_sql_statement;
   std::shared_ptr<AbstractLQPNode> _unoptimized_logical_plan;
-  std::shared_ptr<AbstractLQPNode> _optimized_logical_plan;
+  OptimizedLogicalQueryPlan _optimized_logical_plan;
   std::shared_ptr<AbstractOperator> _physical_plan;
 
   std::shared_ptr<OperatorTask> _root_operator_task;

--- a/src/test/lib/logical_query_plan/stored_table_node_test.cpp
+++ b/src/test/lib/logical_query_plan/stored_table_node_test.cpp
@@ -366,22 +366,22 @@ TEST_F(StoredTableNodeTest, UniqueColumnCombinationsEmpty) {
   EXPECT_TRUE(_stored_table_node->unique_column_combinations().empty());
 }
 
-TEST_F(StoredTableNodeTest, HasMatchingUniqueColumnCombination) {
+TEST_F(StoredTableNodeTest, GetMatchingUniqueColumnCombination) {
   const auto key_constraint_a = TableKeyConstraint{{_a->original_column_id}, KeyConstraintType::UNIQUE};
   _table_a->add_soft_key_constraint(key_constraint_a);
   EXPECT_EQ(_stored_table_node->unique_column_combinations().size(), 1);
 
   // Negative test.
-  EXPECT_FALSE(_stored_table_node->has_matching_ucc({_b}));
-  EXPECT_FALSE(_stored_table_node->has_matching_ucc({_c}));
-  EXPECT_FALSE(_stored_table_node->has_matching_ucc({_b, _c}));
+  EXPECT_FALSE(_stored_table_node->get_matching_ucc({_b}).has_value());
+  EXPECT_FALSE(_stored_table_node->get_matching_ucc({_c}).has_value());
+  EXPECT_FALSE(_stored_table_node->get_matching_ucc({_b, _c}).has_value());
 
   // Test exact match.
-  EXPECT_TRUE(_stored_table_node->has_matching_ucc({_a}));
+  EXPECT_TRUE(_stored_table_node->get_matching_ucc({_a}).has_value());
 
   // Test superset of column ids.
-  EXPECT_TRUE(_stored_table_node->has_matching_ucc({_a, _b}));
-  EXPECT_TRUE(_stored_table_node->has_matching_ucc({_a, _c}));
+  EXPECT_TRUE(_stored_table_node->get_matching_ucc({_a, _b}).has_value());
+  EXPECT_TRUE(_stored_table_node->get_matching_ucc({_a, _c}).has_value());
 }
 
 }  // namespace hyrise

--- a/src/test/lib/optimizer/optimizer_test.cpp
+++ b/src/test/lib/optimizer/optimizer_test.cpp
@@ -10,8 +10,10 @@
 #include "logical_query_plan/predicate_node.hpp"
 #include "logical_query_plan/projection_node.hpp"
 #include "logical_query_plan/sort_node.hpp"
+#include "logical_query_plan/stored_table_node.hpp"
 #include "optimizer/optimizer.hpp"
 #include "optimizer/strategy/abstract_rule.hpp"
+#include "optimizer/strategy/join_to_semi_join_rule.hpp"
 
 namespace hyrise {
 
@@ -164,13 +166,14 @@ TEST_F(OptimizerTest, VerifiesResults) {
     }
 
    protected:
-    void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override {
+    IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override {
       // Change the `b` expression in the projection to `u`, which is not part of the input LQP.
       const auto projection_node = std::dynamic_pointer_cast<ProjectionNode>(lqp_root->left_input());
       if (!projection_node) {
-        return;
+        return IsCacheable::Yes;
       }
       projection_node->node_expressions[0] = _out_of_plan_expression;
+      return IsCacheable::Yes;
     }
 
     std::shared_ptr<AbstractExpression> _out_of_plan_expression;
@@ -198,11 +201,13 @@ TEST_F(OptimizerTest, OptimizesSubqueries) {
     }
 
    protected:
-    void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override {
+    IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override {
       visit_lqp(lqp_root, [&](const auto& node) {
         nodes.emplace(node);
         return LQPVisitation::VisitInputs;
       });
+
+      return IsCacheable::Yes;
     }
 
     std::unordered_set<std::shared_ptr<AbstractLQPNode>>& nodes;
@@ -287,8 +292,9 @@ TEST_F(OptimizerTest, OptimizesSubqueriesExactlyOnce) {
     size_t& counter;
 
    protected:
-    void _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override {
+    IsCacheable _apply_to_plan_without_subqueries(const std::shared_ptr<AbstractLQPNode>& lqp_root) const override {
       ++counter;
+      return IsCacheable::Yes;
     }
   };
 
@@ -297,7 +303,7 @@ TEST_F(OptimizerTest, OptimizesSubqueriesExactlyOnce) {
   Optimizer optimizer{};
   optimizer.add_rule(std::move(rule));
 
-  const auto optimized_lqp = optimizer.optimize(std::move(lqp));
+  const auto optimized_lqp = optimizer.optimize(std::move(lqp)).logical_query_plan;
   lqp = nullptr;
 
   /**
@@ -331,4 +337,43 @@ TEST_F(OptimizerTest, OptimizesSubqueriesExactlyOnce) {
   }
 }
 
+TEST_F(OptimizerTest, CheckTrueCacheablility) {
+  auto optimizer = Optimizer::create_default_optimizer();
+
+  auto lqp = ProjectionNode::make(expression_vector(add_(b, subquery_a)),
+                                  PredicateNode::make(greater_than_(a, subquery_b), node_a));
+  auto optimize_results = optimizer->optimize(std::move(lqp));
+  EXPECT_EQ(optimize_results.cacheable, true);
+}
+
+TEST_F(OptimizerTest, CheckFalseCacheabilityOfOptimization) {
+  auto optimizer = Optimizer{};
+  optimizer.add_rule(std::make_unique<JoinToSemiJoinRule>());
+
+  auto column_definitions = TableColumnDefinitions{};
+  column_definitions.emplace_back("column0", DataType::Int, false);
+  const auto table = std::make_shared<Table>(column_definitions, TableType::Data, ChunkOffset{2}, UseMvcc::Yes);
+
+  auto& sm = Hyrise::get().storage_manager;
+  sm.add_table("table", table);
+
+  // Non-permanent UCC
+  table->add_soft_key_constraint({{ColumnID{0}}, KeyConstraintType::UNIQUE, CommitID{0}});
+
+  const auto stored_table_node = StoredTableNode::make("table");
+  const auto column0 = stored_table_node->get_column("column0");
+
+  // clang-format off
+  auto lqp1 =
+    ProjectionNode::make(expression_vector(add_(a, 2)),
+      JoinNode::make(JoinMode::Inner, equals_(a, column0),
+        ProjectionNode::make(expression_vector(a),
+          node_a),
+        stored_table_node));
+  // clang-format on
+  static_cast<JoinNode&>(*lqp1->left_input()).mark_input_side_as_prunable(LQPInputSide::Right);
+  auto optimize_results1 = optimizer.optimize(std::move(lqp1));
+
+  EXPECT_EQ(optimize_results1.cacheable, false);
+}
 }  // namespace hyrise

--- a/src/test/lib/optimizer/strategy/between_composition_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/between_composition_rule_test.cpp
@@ -446,4 +446,11 @@ TEST_F(BetweenCompositionTest, HandleMultipleEqualExpressions) {
   EXPECT_LQP_EQ(result_lqp, expected_lqp);
 }
 
+TEST_F(BetweenCompositionTest, CheckCacheability) {
+  const auto input_lqp = PredicateNode::make(equals_(_a_a, 100), PredicateNode::make(equals_(_a_b, 100), _node_a));
+  const auto lqp_result = StrategyBaseTest::apply_rule_with_cacheability_check(_rule, input_lqp);
+  const auto cacheable = lqp_result.cacheable;
+  EXPECT_EQ(cacheable, true);
+}
+
 }  // namespace hyrise

--- a/src/test/lib/optimizer/strategy/chunk_pruning_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/chunk_pruning_rule_test.cpp
@@ -480,4 +480,14 @@ TEST_F(ChunkPruningRuleTest, PredicateWithCorrelatedSubquery) {
   EXPECT_EQ(stored_table_node_1->pruned_chunk_ids(), expected_chunk_ids);
 }
 
+TEST_F(ChunkPruningRuleTest, CheckCacheability) {
+  const auto stored_table_node = StoredTableNode::make("fixed_string_compressed");
+
+  const auto predicate_node = PredicateNode::make(equals_(lqp_column_(stored_table_node, ColumnID{0}), "zzz"));
+  predicate_node->set_left_input(stored_table_node);
+
+  const auto lqp_result = StrategyBaseTest::apply_rule_with_cacheability_check(_rule, predicate_node);
+  const auto cacheable = lqp_result.cacheable;
+  EXPECT_EQ(cacheable, true);
+}
 }  // namespace hyrise

--- a/src/test/lib/optimizer/strategy/column_pruning_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/column_pruning_rule_test.cpp
@@ -483,4 +483,12 @@ TEST_F(ColumnPruningRuleTest, AnnotatePrunableJoinInput) {
   }
 }
 
+TEST_F(ColumnPruningRuleTest, CheckCacheability) {
+  const auto lqp = ExportNode::make("dummy.csv", FileType::Auto, PredicateNode::make(greater_than_(a, 5), node_abc));
+
+  const auto lqp_result = apply_rule_with_cacheability_check(rule, lqp);
+  const auto cacheable = lqp_result.cacheable;
+  EXPECT_EQ(cacheable, true);
+}
+
 }  // namespace hyrise

--- a/src/test/lib/optimizer/strategy/in_expression_rewrite_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/in_expression_rewrite_rule_test.cpp
@@ -373,4 +373,13 @@ TEST_F(InExpressionRewriteRuleTest, AutoStrategy) {
   }
 }
 
+TEST_F(InExpressionRewriteRuleTest, CheckCacheability) {
+  auto rule = std::make_shared<InExpressionRewriteRule>();
+  rule->strategy = InExpressionRewriteRule::Strategy::ExpressionEvaluator;
+  const auto input_lqp = PredicateNode::make(single_element_in_expression, node);
+  const auto lqp_result = StrategyBaseTest::apply_rule_with_cacheability_check(rule, input_lqp);
+  const auto cacheable = lqp_result.cacheable;
+  EXPECT_EQ(cacheable, true);
+}
+
 }  // namespace hyrise

--- a/src/test/lib/optimizer/strategy/index_scan_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/index_scan_rule_test.cpp
@@ -177,4 +177,14 @@ TEST_F(IndexScanRuleTest, IndexScanOnlyOnOutputOfStoredTableNode) {
   EXPECT_EQ(predicate_node_1->scan_type, ScanType::TableScan);
 }
 
+TEST_F(IndexScanRuleTest, CheckCacheability) {
+  auto predicate_node_0 = PredicateNode::make(greater_than_(a, 10));
+  predicate_node_0->set_left_input(stored_table_node);
+
+  EXPECT_EQ(predicate_node_0->scan_type, ScanType::TableScan);
+  const auto lqp_result = StrategyBaseTest::apply_rule_with_cacheability_check(rule, predicate_node_0);
+  const auto cacheable = lqp_result.cacheable;
+  EXPECT_EQ(cacheable, true);
+}
+
 }  // namespace hyrise

--- a/src/test/lib/optimizer/strategy/join_ordering_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/join_ordering_rule_test.cpp
@@ -78,4 +78,19 @@ TEST_F(JoinOrderingRuleTest, MultipleJoinGraphs) {
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
 
+TEST_F(JoinOrderingRuleTest, CheckCacheability) {
+  const auto input_lqp = AggregateNode::make(
+      expression_vector(a_a), expression_vector(),
+      PredicateNode::make(
+          equals_(a_a, b_b),
+          JoinNode::make(JoinMode::Cross, node_a,
+                         JoinNode::make(JoinMode::Left, equals_(b_b, d_d), node_b,
+                                        PredicateNode::make(equals_(d_d, c_c),
+                                                            JoinNode::make(JoinMode::Cross, node_d, node_c))))));
+
+  const auto lqp_result = StrategyBaseTest::apply_rule_with_cacheability_check(rule, input_lqp);
+  const auto cacheable = lqp_result.cacheable;
+  EXPECT_EQ(cacheable, true);
+}
+
 }  // namespace hyrise

--- a/src/test/lib/optimizer/strategy/join_predicate_ordering_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/join_predicate_ordering_rule_test.cpp
@@ -123,4 +123,18 @@ TEST_F(JoinPredicateOrderingRuleTest, SemiGreaterAndEquiJoin) {
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
 
+TEST_F(JoinPredicateOrderingRuleTest, CheckCacheability) {
+  set_statistics_for_mock_node(node_b, 100,
+                               {GenericHistogram<int32_t>::with_single_bin(0, 40, 100, 5),
+                                GenericHistogram<int32_t>::with_single_bin(30, 70, 100, 5),
+                                GenericHistogram<int32_t>::with_single_bin(10, 50, 100, 5)});
+
+  const auto predicates = expression_vector(greater_than_(a_y, b_y), less_than_(a_z, b_z));
+
+  const auto input_lqp = JoinNode::make(JoinMode::Inner, predicates, node_a, node_b);
+  const auto lqp_result = StrategyBaseTest::apply_rule_with_cacheability_check(_rule, input_lqp);
+  const auto cacheable = lqp_result.cacheable;
+  EXPECT_EQ(cacheable, true);
+}
+
 }  // namespace hyrise

--- a/src/test/lib/optimizer/strategy/null_scan_removal_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/null_scan_removal_rule_test.cpp
@@ -102,4 +102,11 @@ TEST_F(NullScanRemovalRuleTest, TableColumnDefinitionIsNotNullable) {
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
 
+TEST_F(NullScanRemovalRuleTest, CheckCacheability) {
+  const auto input_lqp = PredicateNode::make(is_not_null_(table_node_column), table_node);
+  const auto lqp_result = StrategyBaseTest::apply_rule_with_cacheability_check(rule, input_lqp);
+  const auto cacheable = lqp_result.cacheable;
+  EXPECT_EQ(cacheable, true);
+}
+
 }  // namespace hyrise

--- a/src/test/lib/optimizer/strategy/predicate_merge_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/predicate_merge_rule_test.cpp
@@ -392,4 +392,11 @@ TEST_F(PredicateMergeRuleTest, NoRewriteDifferentSetOperationMode) {
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
 
+TEST_F(PredicateMergeRuleTest, CheckCacheability) {
+  const auto input_lqp = PredicateNode::make(less_than_(a_a, 10), node_a);
+  const auto lqp_result = StrategyBaseTest::apply_rule_with_cacheability_check(rule, input_lqp);
+  const auto cacheable = lqp_result.cacheable;
+  EXPECT_EQ(cacheable, true);
+}
+
 }  // namespace hyrise

--- a/src/test/lib/optimizer/strategy/predicate_placement_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/predicate_placement_rule_test.cpp
@@ -922,4 +922,13 @@ TEST_F(PredicatePlacementRuleTest, DoNotCreatePreJoinPredicateIfUnrelated) {
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
 
+TEST_F(PredicatePlacementRuleTest, CheckCacheability) {
+  const auto input_lqp = PredicateNode::make(
+      or_(and_(equals_(_d_b, 1), equals_(_e_a, 10)), and_(equals_(_d_b, 2), equals_(_e_a, 1))),  // NOLINT
+      JoinNode::make(JoinMode::Left, equals_(_d_a, _e_a), _stored_table_d, _stored_table_e));
+  const auto lqp_result = StrategyBaseTest::apply_rule_with_cacheability_check(_rule, input_lqp);
+  const auto cacheable = lqp_result.cacheable;
+  EXPECT_EQ(cacheable, true);
+}
+
 }  // namespace hyrise

--- a/src/test/lib/optimizer/strategy/predicate_reordering_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/predicate_reordering_rule_test.cpp
@@ -269,4 +269,11 @@ TEST_F(PredicateReorderingTest, SimpleValidateReorderingTest) {
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
 
+TEST_F(PredicateReorderingTest, CheckCacheability) {
+  const auto input_lqp = PredicateNode::make(greater_than_(a, 60), ValidateNode::make(node));
+  const auto lqp_result = StrategyBaseTest::apply_rule_with_cacheability_check(_rule, input_lqp);
+  const auto cacheable = lqp_result.cacheable;
+  EXPECT_EQ(cacheable, true);
+}
+
 }  // namespace hyrise

--- a/src/test/lib/optimizer/strategy/predicate_split_up_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/predicate_split_up_rule_test.cpp
@@ -341,4 +341,11 @@ TEST_F(PredicateSplitUpRuleTest, NoRewriteSimplePredicate) {
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
 
+TEST_F(PredicateSplitUpRuleTest, CheckCacheability) {
+  const auto input_lqp = PredicateNode::make(less_than_(a_a, value_(10)), node_a);
+  const auto lqp_result = StrategyBaseTest::apply_rule_with_cacheability_check(rule, input_lqp);
+  const auto cacheable = lqp_result.cacheable;
+  EXPECT_EQ(cacheable, true);
+}
+
 }  // namespace hyrise

--- a/src/test/lib/optimizer/strategy/semi_join_reduction_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/semi_join_reduction_rule_test.cpp
@@ -223,4 +223,11 @@ TEST_F(SemiJoinReductionRuleTest, NoReductionForAntiJoin) {
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
 
+TEST_F(SemiJoinReductionRuleTest, CheckCacheability) {
+  const auto input_lqp = JoinNode::make(JoinMode::AntiNullAsTrue, equals_(_a_a, _b_a), _node_a, _node_b);
+  const auto lqp_result = StrategyBaseTest::apply_rule_with_cacheability_check(_rule, input_lqp);
+  const auto cacheable = lqp_result.cacheable;
+  EXPECT_EQ(cacheable, true);
+}
+
 }  // namespace hyrise

--- a/src/test/lib/optimizer/strategy/stored_table_column_alignment_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/stored_table_column_alignment_rule_test.cpp
@@ -109,4 +109,10 @@ TEST_F(StoredTableColumnAlignmentRuleTest, CoverSubqueries) {
   EXPECT_EQ(stn_subquery->pruned_column_ids(), pruned_column_set_a);
 }
 
+TEST_F(StoredTableColumnAlignmentRuleTest, CheckCacheability) {
+  const auto lqp_result = apply_rule_with_cacheability_check(_rule, _union_node);
+  const auto cacheable = lqp_result.cacheable;
+  EXPECT_EQ(cacheable, true);
+}
+
 }  // namespace hyrise

--- a/src/test/lib/optimizer/strategy/strategy_base_test.cpp
+++ b/src/test/lib/optimizer/strategy/strategy_base_test.cpp
@@ -7,6 +7,7 @@
 #include "cost_estimation/cost_estimator_logical.hpp"
 #include "logical_query_plan/abstract_lqp_node.hpp"
 #include "logical_query_plan/logical_plan_root_node.hpp"
+#include "optimizer/optimizer.hpp"
 #include "optimizer/strategy/abstract_rule.hpp"
 #include "statistics/cardinality_estimator.hpp"
 
@@ -14,6 +15,12 @@ namespace hyrise {
 
 std::shared_ptr<AbstractLQPNode> StrategyBaseTest::apply_rule(const std::shared_ptr<AbstractRule>& rule,
                                                               const std::shared_ptr<AbstractLQPNode>& input) {
+  const auto lqp_result = apply_rule_with_cacheability_check(rule, input);
+  return lqp_result.logical_query_plan;
+}
+
+OptimizedLogicalQueryPlan StrategyBaseTest::apply_rule_with_cacheability_check(
+    const std::shared_ptr<AbstractRule>& rule, const std::shared_ptr<AbstractLQPNode>& input) {
   // Add explicit root node
   const auto root_node = LogicalPlanRootNode::make();
   root_node->set_left_input(input);
@@ -23,13 +30,13 @@ std::shared_ptr<AbstractLQPNode> StrategyBaseTest::apply_rule(const std::shared_
   const auto cost_estimator = std::make_shared<CostEstimatorLogical>(cardinality_estimator);
   rule->cost_estimator = cost_estimator;
 
-  rule->apply_to_plan(root_node);
+  const auto cacheable = rule->apply_to_plan(root_node);
 
   // Remove LogicalPlanRootNode
   const auto optimized_node = root_node->left_input();
   root_node->set_left_input(nullptr);
 
-  return optimized_node;
+  return {static_cast<bool>(cacheable), optimized_node};
 }
 
 }  // namespace hyrise

--- a/src/test/lib/optimizer/strategy/strategy_base_test.hpp
+++ b/src/test/lib/optimizer/strategy/strategy_base_test.hpp
@@ -15,6 +15,8 @@ class StrategyBaseTest : public BaseTest {
    * Helper method for applying a single rule to an LQP. Creates the temporary LogicalPlanRootNode and returns its input
    * after applying the rule
    */
+  OptimizedLogicalQueryPlan apply_rule_with_cacheability_check(const std::shared_ptr<AbstractRule>& rule,
+                                                               const std::shared_ptr<AbstractLQPNode>& input);
   std::shared_ptr<AbstractLQPNode> apply_rule(const std::shared_ptr<AbstractRule>& rule,
                                               const std::shared_ptr<AbstractLQPNode>& input);
 };

--- a/src/test/lib/optimizer/strategy/subquery_to_join_rule_test.cpp
+++ b/src/test/lib/optimizer/strategy/subquery_to_join_rule_test.cpp
@@ -1546,4 +1546,11 @@ TEST_F(SubqueryToJoinRuleTest, ComplexArithmeticExpression) {
   EXPECT_LQP_EQ(actual_lqp, expected_lqp);
 }
 
+TEST_F(SubqueryToJoinRuleTest, CheckCacheability) {
+  const auto input_lqp = PredicateNode::make(in_(a_a, list_(1, 2, 3)), node_a);
+  const auto lqp_result = StrategyBaseTest::apply_rule_with_cacheability_check(_rule, input_lqp);
+  const auto cacheable = lqp_result.cacheable;
+  EXPECT_EQ(cacheable, true);
+}
+
 }  // namespace hyrise


### PR DESCRIPTION
Make sure to only use UCCs in optimization that are  `guaranteed_to_be_valid`.

Also, we want to ensure that Hyrise only caches logical and physical query plans that cannot become invalid, because executing an invalid query plan might produce incorrect results. Query plans could become invalid if they have been optimized using UCCs that are not permanent, e.g., incidental UCCs discovered by the `UccDiscoveryPlugin`. The same can happen if a Functional Dependency (FD) was used that was derived from a non-permanent UCC. We ensure correct caching by having each optimization rule return whether the resulting Logical Query Plan can be cached.

_Note that this PR currently targets [our first PR branch](https://github.com/hyrise/hyrise/pull/2591), in order to not include the changes from there again here :) Please review the other PR before this one. We will change the PR to target master before merging._


